### PR TITLE
Add an attribute that lets you set the export location

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ describe file('/etc/haproxy/haproxy.cfg') do
 end
 ```
 
-Windows instances will store the node data in `%TEMP%\kitchen\chef_node.json` and other platforms will store the node data in `/tmp/kitchen/chef_node.json`.
+Windows instances will store the node data in `%TEMP%\kitchen\chef_node.json` and other platforms will store the node data in `/tmp/kitchen/chef_node.json`. 
+
+The export location can be changed by setting `node['export-node']['location']`to a folder.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['export-node']['location']  = File.join(ENV["TEMP"] || "/tmp", "kitchen")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,6 @@
 ruby_block "Save node attributes" do
   block do
-    parent = File.join(ENV["TEMP"] || "/tmp", "kitchen")
+  	parent = node['export-node']['location']
     IO.write(File.join(parent, "chef_node.json"), node.to_json) if Dir::exist?(parent)
   end
 end


### PR DESCRIPTION
We are using your cookbook to add some extra info to our images so that when we bring up an old image we have know more about it. I made a small change that allows you to set the export location to some place a bit more accessible.

I know its not your primary use case, but I'm sure others will find this handy to have.